### PR TITLE
Create React-based CV page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-- 👋 Hi, I’m @phanchitra
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# Phan Chitra CV
 
-<!---
-phanchitra/phanchitra is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This project contains a simple React application that renders Phan Chitra's curriculum vitae.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open the URL shown in the terminal to view the CV.
+
+## Build for Production
+
+```bash
+npm run build
+```
+
+To preview the production build locally:
+
+```bash
+npm run preview
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phan Chitra | CV</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "phanchitra-cv",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/CV.jsx
+++ b/src/CV.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+export default function CV() {
+  return (
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center p-6">
+      <div className="bg-white max-w-4xl w-full rounded-2xl shadow-xl p-8">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b pb-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-800">Phan Chitra</h1>
+            <p className="text-gray-600">
+              Telecommunication & Networking Engineer | Digital Marketing | Event Planner
+            </p>
+          </div>
+          <div className="text-right text-sm">
+            <p className="text-gray-700">📞 +855 66 306 250</p>
+            <p className="text-gray-700">✉️ phanchitra143@gmail.com</p>
+            <p className="text-gray-700">📍 Phnom Penh, Cambodia</p>
+          </div>
+        </div>
+
+        {/* Summary */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Summary</h2>
+          <p className="text-gray-700">
+            5th-year student in Telecommunication and Network Engineering at ITC.
+            Experienced in technical services, digital marketing, and event planning.
+            Vice President of SANITC 30, passionate about technology, teamwork, and community involvement.
+          </p>
+        </section>
+
+        {/* Experience */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Work Experience</h2>
+          <div className="space-y-3">
+            <div>
+              <h3 className="font-semibold text-gray-700">Intersys Solutions Co., Ltd</h3>
+              <p className="text-sm text-gray-600">Trainee | Feb – Jul 2025 &amp; Jul – Oct 2024</p>
+              <p className="text-gray-700">
+                Hands-on experience in technical service operations, ELV systems, and industry best practices.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-700">Ezecom Company Ltd.</h3>
+              <p className="text-sm text-gray-600">Trainee | 2023</p>
+              <p className="text-gray-700">
+                Worked in Technical Service and Digital Marketing departments. Learned telecommunications operations and
+                digital campaigns.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-700">Spai</h3>
+              <p className="text-sm text-gray-600">Trainee | 2023</p>
+              <p className="text-gray-700">
+                Assisted in digital marketing strategies, social media management, and online promotions.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Education */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Education</h2>
+          <ul className="list-disc list-inside text-gray-700">
+            <li>
+              <b>2020 – 2025:</b> ITC – Telecommunication &amp; Network Engineering
+            </li>
+            <li>
+              <b>2014 – 2020:</b> Sok An Tram Khnar High School
+            </li>
+            <li>
+              <b>2008 – 2014:</b> Trapeang Kuch Primary School
+            </li>
+          </ul>
+        </section>
+
+        {/* Leadership & Community */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Volunteer &amp; Leadership</h2>
+          <ul className="list-disc list-inside text-gray-700">
+            <li>Vice President – SANITC 30</li>
+            <li>Organizer – Sangkranta Techno</li>
+            <li>Sponsor &amp; Marketing Lead – Sangkranta Techno</li>
+            <li>Volunteer – Angkor Songkran, 32nd SEA Games, ASEAN Para Games, CAFEO-40</li>
+          </ul>
+        </section>
+
+        {/* Skills */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Skills</h2>
+          <div className="grid grid-cols-2 gap-2 text-gray-700">
+            <p>Huawei ICT</p>
+            <p>Microsoft Office</p>
+            <p>Java, C/C++</p>
+            <p>Canva, Video Editing</p>
+            <p>Leadership &amp; Communication</p>
+            <p>Teamwork &amp; Time Management</p>
+          </div>
+        </section>
+
+        {/* Languages */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Languages</h2>
+          <p className="text-gray-700">Khmer (Native), English (Professional)</p>
+        </section>
+
+        {/* Hobbies */}
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Hobbies &amp; Interests</h2>
+          <p className="text-gray-700">Football, Badminton, Volunteering, Gaming, Traveling, Photo/Video Editing</p>
+        </section>
+
+        {/* Reference */}
+        <section>
+          <h2 className="text-xl font-semibold text-gray-800 mb-2">Reference</h2>
+          <p className="text-gray-700">
+            Dr. Sreng Sokchenda – Head of Department, ITC <br />
+            📞 012 407 910 | ✉️ sokchenda@itc.edu.kh
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import CV from './CV.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <CV />
+  </React.StrictMode>,
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up a Vite-powered React application that renders Phan Chitra's CV content
- add project documentation and HTML entry point configured with Tailwind via CDN

## Testing
- npm install *(fails: 403 Forbidden when fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf7b778b8832d8e3a8a4ff1fff8ff